### PR TITLE
Updated versions of Hanser and Addison Wesley books

### DIFF
--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -18,10 +18,10 @@ This section contains references that are cited in the curriculum.
 
 
 - [[[bachmann,Bachmann 2000]]] Bachmann, F., L. Bass, et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.
-- [[[bass,Bass 2003]]] Bass, L., Clements, P. und Kazman, R. (2003): Software Architecture in Practice. Addison-Wesley, Reading, Mass
+- [[[bass,Bass 2021]]] Bass, L., Clements, P. und Kazman, R.: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
 
 
-- [[[clements,Clements+2003]]] Clements, P., F. Bachmann, L. Bass, D. Garlan, J. Ivers et al: Documenting Software Architectures – Views and Beyond. Addison Wesley, 2003.
+- [[[clements,Clements+2010]]] Clements, P., F. Bachmann, L. Bass, D. Garlan, J. Ivers et al: Documenting Software Architectures – Views and Beyond. 2. Edition, Addison Wesley 2010.
 
 
 - [[[hargis,Hargis+2004]]] Hargis, Gretchen et. al: Quality Technical Information: A Handbook for Writers and Editors. Prentice Hall, IBM Press, 2004.
@@ -32,7 +32,7 @@ This section contains references that are cited in the curriculum.
 
 - [[[nygard,Nygard]]] Nygard, Michael: Documenting Architecture Decision. <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>. See also <https://adr.github.io/>
 
-- [[[starke,Starke 2019]]] Starke, Gernot: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 9. Auflage 2019, Carl Hanser Verlag, München.
+- [[[starke,Starke 2020]]] Starke, Gernot: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 9. Auflage 2020, Carl Hanser Verlag, München.
 
 - [[[starkehruschka,Starke+2016]]] Gernot Starke, Peter Hruschka: Communicating Software Architectures: lean, effective and painless documentation.
 Leanpub <https://leanpub.com/arc42inpractice>


### PR DESCRIPTION
New editions available for two books from Addison-Wesley.
And the year at one Hanser book is wrong for the given editions.