### PR TITLE
Names of authors in references now written the same way (e.g. "S. Brown")

### DIFF
--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -12,6 +12,8 @@ Dieser Abschnitt enthält Quellenangaben, die ganz oder teilweise im Curriculum 
 This section contains references that are cited in the curriculum.
 // end::EN[]
 
+**B**
+
 - [[[bachmann,Bachmann 2000]]] F. Bachmann, L. Bass et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.
 
 - [[[bass,Bass 2021]]] L. Bass, P. Clements und R. Kazman: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
@@ -20,19 +22,33 @@ This section contains references that are cited in the curriculum.
 
 - [[[brown-sg,Brown (Guidebook)]]] S. Brown: The software guidebook. A guide to documenting your software architecture. Leanpub <https://leanpub.com/documenting-software-architecture>
 
+**C**
+
 - [[[clements,Clements+2010]]] P. Clements, F. Bachmann, L. Bass, D. Garlan, J. Ivers et al.: Documenting Software Architectures – Views and Beyond. 2. Edition 2010, Addison Wesley.
+
+**H**
 
 - [[[hargis,Hargis+2004]]] G. Hargis et al.: Quality Technical Information: A Handbook for Writers and Editors. Prentice Hall, IBM Press, 2004.
 
+**K**
+
 - [[[kruchten,Kruchten 1995]]] P. Kruchten: Architectural Blueprints – The 4-1 View Model of Architecture. IEEE Software November 1995; 12(6), p. 42-50.
 
+**N**
+
 - [[[nygard,Nygard]]] M. Nygard: Documenting Architecture Decisions. <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>. See also <https://adr.github.io/>
+
+**S**
 
 - [[[starke,Starke 2024]]] G. Starke: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 10. Auflage 2024, Carl Hanser Verlag, München.
 
 - [[[starkehruschka,Starke+2016]]] G. Starke, P. Hruschka: Communicating Software Architectures: lean, effective and painless documentation.
 Leanpub <https://leanpub.com/arc42inpractice>
 
+**U**
+
 - [[[UML,UML]]] Universal Modeling Language, homepage: <https://www.uml.org>. Provides both the standard plus a collection of resources for further information.
+
+**Z**
 
 - [[[zoerner, Zörner 2021]]] S. Zörner: Softwarearchitekturen dokumentieren und kommunizieren: Entwürfe, Entscheidungen und Lösungen nachvollziehbar und wirkungsvoll festhalten. 3. Auflage 2021, Carl-Hanser Verlag.

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -14,7 +14,7 @@ This section contains references that are cited in the curriculum.
 
 **B**
 
-- [[[bachmann,Bachmann 2000]]] F. Bachmann, L. Bass et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.
+- [[[bachmann,Bachmann 2000]]] F. Bachmann, L. Bass et al.: Software Architecture Documentation in Practice. Software Engineering Institute, Special Report 2000, CMU/SEI-2000-SR-004.
 
 - [[[bass,Bass 2021]]] L. Bass, P. Clements und R. Kazman: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
 

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -18,9 +18,9 @@ This section contains references that are cited in the curriculum.
 
 - [[[bass,Bass 2021]]] L. Bass, P. Clements und R. Kazman: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
 
-- [[[brown-c4,Brown (C4)]]] S. Brown: The C4 model for visualising software architecture. Leanpub <https://leanpub.com/visualising-software-architecture>
+- [[[brown-c4,Brown (C4)]]] S. Brown: The C4 model for visualising software architecture. Leanpub https://leanpub.com/visualising-software-architecture
 
-- [[[brown-sg,Brown (Guidebook)]]] S. Brown: The software guidebook. A guide to documenting your software architecture. Leanpub <https://leanpub.com/documenting-software-architecture>
+- [[[brown-sg,Brown (Guidebook)]]] S. Brown: The software guidebook. A guide to documenting your software architecture. Leanpub https://leanpub.com/documenting-software-architecture
 
 **C**
 
@@ -43,11 +43,11 @@ This section contains references that are cited in the curriculum.
 - [[[starke,Starke 2024]]] G. Starke: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 10. Auflage 2024, Carl Hanser Verlag, München.
 
 - [[[starkehruschka,Starke+2016]]] G. Starke, P. Hruschka: Communicating Software Architectures: lean, effective and painless documentation.
-Leanpub <https://leanpub.com/arc42inpractice>
+Leanpub https://leanpub.com/arc42inpractice
 
 **U**
 
-- [[[UML,UML]]] Universal Modeling Language, homepage: <https://www.uml.org>. Provides both the standard plus a collection of resources for further information.
+- [[[UML,UML]]] Universal Modeling Language, homepage: https://www.uml.org. Provides both the standard plus a collection of resources for further information.
 
 **Z**
 

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -12,27 +12,27 @@ Dieser Abschnitt enthält Quellenangaben, die ganz oder teilweise im Curriculum 
 This section contains references that are cited in the curriculum.
 // end::EN[]
 
-- [[[bachmann,Bachmann 2000]]] Bachmann, F., L. Bass, et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.
+- [[[bachmann,Bachmann 2000]]] F. Bachmann, L. Bass et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.
 
-- [[[bass,Bass 2021]]] Bass, L., Clements, P. und Kazman, R.: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
+- [[[bass,Bass 2021]]] L. Bass, P. Clements und R. Kazman: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
 
-- [[[brown-c4,Brown (C4)]]] Brown, S.:, R.: The C4 model for visualising software architecture. Leanpub <https://leanpub.com/visualising-software-architecture>
+- [[[brown-c4,Brown (C4)]]] S. Brown: The C4 model for visualising software architecture. Leanpub <https://leanpub.com/visualising-software-architecture>
 
-- [[[brown-sg,Brown (Guidebook)]]] Brown, S.:, R.: The software guidebook. A guide to documenting your software architecture. Leanpub <https://leanpub.com/documenting-software-architecture>
+- [[[brown-sg,Brown (Guidebook)]]] S. Brown: The software guidebook. A guide to documenting your software architecture. Leanpub <https://leanpub.com/documenting-software-architecture>
 
-- [[[clements,Clements+2010]]] Clements, P., F. Bachmann, L. Bass, D. Garlan, J. Ivers et al: Documenting Software Architectures – Views and Beyond. 2. Edition, Addison Wesley 2010.
+- [[[clements,Clements+2010]]] P. Clements, F. Bachmann, L. Bass, D. Garlan, J. Ivers et al.: Documenting Software Architectures – Views and Beyond. 2. Edition 2010, Addison Wesley.
 
-- [[[hargis,Hargis+2004]]] Hargis, Gretchen et. al: Quality Technical Information: A Handbook for Writers and Editors. Prentice Hall, IBM Press, 2004.
+- [[[hargis,Hargis+2004]]] G. Hargis et al.: Quality Technical Information: A Handbook for Writers and Editors. Prentice Hall, IBM Press, 2004.
 
-- [[[kruchten,Kruchten 1995]]] Kruchten, P.: Architectural Blueprints – The 4-1 View Model of Architecture. IEEE Software November 1995; 12(6), p. 42-50.
+- [[[kruchten,Kruchten 1995]]] P. Kruchten: Architectural Blueprints – The 4-1 View Model of Architecture. IEEE Software November 1995; 12(6), p. 42-50.
 
-- [[[nygard,Nygard]]] Nygard, Michael: Documenting Architecture Decision. <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>. See also <https://adr.github.io/>
+- [[[nygard,Nygard]]] M. Nygard: Documenting Architecture Decisions. <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>. See also <https://adr.github.io/>
 
-- [[[starke,Starke 2024]]] Starke, Gernot: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 10. Auflage 2024, Carl Hanser Verlag, München.
+- [[[starke,Starke 2024]]] G. Starke: Effektive Softwarearchitekturen - Ein praktischer Leitfaden. 10. Auflage 2024, Carl Hanser Verlag, München.
 
-- [[[starkehruschka,Starke+2016]]] Gernot Starke, Peter Hruschka: Communicating Software Architectures: lean, effective and painless documentation.
+- [[[starkehruschka,Starke+2016]]] G. Starke, P. Hruschka: Communicating Software Architectures: lean, effective and painless documentation.
 Leanpub <https://leanpub.com/arc42inpractice>
 
 - [[[UML,UML]]] Universal Modeling Language, homepage: <https://www.uml.org>. Provides both the standard plus a collection of resources for further information.
 
-- [[[zoerner, Zörner 2021]]] Stefan Zörner: Softwarearchitekturen dokumentieren und kommunizieren: Entwürfe, Entscheidungen und Lösungen nachvollziehbar und wirkungsvoll festhalten. 3. Auflage, Carl-Hanser Verlag 2021
+- [[[zoerner, Zörner 2021]]] S. Zörner: Softwarearchitekturen dokumentieren und kommunizieren: Entwürfe, Entscheidungen und Lösungen nachvollziehbar und wirkungsvoll festhalten. 3. Auflage 2021, Carl-Hanser Verlag.

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -14,8 +14,6 @@ This section contains references that are cited in the curriculum.
 
 **B**
 
-- [[[bachmann,Bachmann 2000]]] F. Bachmann, L. Bass et al.: Software Architecture Documentation in Practice. Software Engineering Institute, Special Report 2000, CMU/SEI-2000-SR-004.
-
 - [[[bass,Bass 2021]]] L. Bass, P. Clements und R. Kazman: Software Architecture in Practice. 4. Edition, Addison-Wesley 2021.
 
 - [[[brown-c4,Brown (C4)]]] S. Brown: The C4 model for visualising software architecture. Leanpub https://leanpub.com/visualising-software-architecture

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -36,7 +36,7 @@ This section contains references that are cited in the curriculum.
 
 **N**
 
-- [[[nygard,Nygard]]] M. Nygard: Documenting Architecture Decisions. <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>. See also <https://adr.github.io/>
+- [[[nygard,Nygard 2011]]] M. Nygard: Documenting Architecture Decisions. Blog Post 2011 https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions. See also https://adr.github.io/
 
 **S**
 


### PR DESCRIPTION
- In order to fix issue  https://github.com/isaqb-org/curriculum-adoc/issues/33
- Plus: Added big letters in the references as a structure. As in the SOFT curriculum for instance.